### PR TITLE
feat: add s6 service and version reporting

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,3 @@
 # ShellCheck configuration
-shell=bash
+shell=sh
 disable=SC3040,SC3020,SC3010,SC3010

--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,13 @@ COPY --from=build /usr/bin/tempo /usr/bin/tempo
 # Configuration directory
 RUN mkdir -p /etc/tempo /var/tempo
 
+# Version reporting
+COPY scripts/container-version.sh /usr/bin/container-version
+
+# s6 service definition
+COPY services/tempo/run /etc/services.d/tempo/run
+RUN chmod +x /usr/bin/container-version /etc/services.d/tempo/run
+
 # Default user setup (tempo)
 ARG USER=tempo
 RUN /usr/sbin/groupmod -n $USER debian \
@@ -46,7 +53,3 @@ EXPOSE 3200 9095
 USER $USER
 WORKDIR /home/$USER
 
-# Entrypoint setup
-# Typically requires -config.file=/etc/tempo/tempo.yaml
-ENTRYPOINT ["/usr/bin/tempo"]
-CMD ["-config.file=/etc/tempo/tempo.yaml"]

--- a/pre-commit-install.sh
+++ b/pre-commit-install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
 # =============================================================================
 # bin/pre-commit
 # Syncs pre-commit config from gautada/cicd and runs pre-commit --all-files.

--- a/scripts/container-version.sh
+++ b/scripts/container-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ VERSION - TEMPO VERSION REPORT                                       │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# Emits the Tempo version baked into the container. Returns "unknown" if the
+# version cannot be determined.
+
+VERSION=$(/usr/bin/tempo --version 2>/dev/null | grep -Eo '([0-9]+\.)+[0-9]+' | head -n 1)
+
+if [ -z "$VERSION" ]; then
+  printf "unknown\n"
+  exit 1
+fi
+
+printf "%s\n" "$VERSION"

--- a/services/tempo/run
+++ b/services/tempo/run
@@ -1,0 +1,19 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ TEMPO - S6 SERVICE SCRIPT                                             │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# Manages the Tempo process under s6 supervision. Ensures runtime directories
+# exist with the correct ownership before launching the binary.
+
+set -euo pipefail
+
+APP_USER="tempo"
+CONFIG_FILE="${TEMPO_CONFIG:-/etc/tempo/tempo.yaml}"
+DATA_PATH="/var/tempo"
+
+mkdir -p "${DATA_PATH}"
+chown -R "${APP_USER}:${APP_USER}" "${DATA_PATH}"
+
+exec s6-setuidgid "${APP_USER}" \
+  /usr/bin/tempo \
+    -config.file="${CONFIG_FILE}"


### PR DESCRIPTION
## Summary

References #1.

- Adds an s6 service run script so Tempo is supervised by the base image's init system instead of running as PID 1.
- Ships a `container-version` helper that surfaces the Tempo version baked into the image.
- Syncs the shared pre-commit configuration so linting runs consistently.

## Testing

- ./pre-commit-install.sh (runs hadolint + shellcheck)
- Inspected the s6 run script to ensure it executes /usr/bin/tempo -config.file=/etc/tempo/tempo.yaml under the tempo user.

## Notes

This repository does not contain a dev branch, so the PR targets main.