### PR TITLE
feat: build tempo from source

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,105 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BASE_IMAGE=docker.io/gautada/debian:latest
+ARG TEMPO_VERSION=2.4.1
+ARG TARGETARCH=amd64
+
+# ══════════════════════════════════════════════════════════════
+# Stage 1: Build Tempo from source
+# ══════════════════════════════════════════════════════════════
+FROM docker.io/library/golang:1.24-trixie AS builder
+
+ARG TEMPO_VERSION
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GOOS=linux
+ENV GOARCH=${TARGETARCH}
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git config --global advice.detachedHead false \
+ && git clone --depth 1 --branch "v${TEMPO_VERSION}" https://github.com/grafana/tempo.git .
+
+RUN go build -ldflags "-s -w" ./cmd/tempo
+
+# ══════════════════════════════════════════════════════════════
+# Stage 2: Final Image
+# ══════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS container
+
+ARG TARGETARCH
+
+# ╭――――――――――――――――――――╮
+# │ METADATA           │
+# ╰――――――――――――――――――――╯
+LABEL org.opencontainers.image.title="tempo"
+LABEL org.opencontainers.image.description="A Grafana Tempo high-scale distributed tracing backend container."
+LABEL org.opencontainers.image.source="https://github.com/gautada/tempo"
+LABEL org.opencontainers.image.license="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Application layout
+RUN mkdir -p /etc/tempo \
+           /var/tempo
+
+# Tempo binary
+COPY --from=builder /build/tempo /usr/bin/tempo
+
+# ╭──────────────────────────────────────────────────────────╮
+# │ User                                                     │
+# ╰──────────────────────────────────────────────────────────╯
+ARG USER=tempo
+RUN /usr/sbin/usermod -l $USER debian \
+ && /usr/sbin/usermod -d /home/$USER -m $USER \
+ && /usr/sbin/groupmod -n $USER debian \
+ && /bin/passwd -d $USER \
+ && rm -rf /home/debian
+
+# ╭――――――――――――――――――――╮
+# │ CONFIGURATION      │
+# ╰――――――――――――――――――――╯
+# Expecting tempo.yaml to be provided via mount or copy
+# For now, we prepare the symlink if we use the same pattern as grafana
+# COPY tempo.yaml /mnt/volumes/configuration/tempo.yaml
+# RUN ln -fsv /mnt/volumes/configuration/tempo.yaml /etc/tempo/tempo.yaml \
+#  && chown $USER:$USER /etc/tempo/tempo.yaml
+
+# ╭――――――――――――――――――――╮
+# │ VERSION            │
+# ╰――――――――――――――――――――╯
+COPY scripts/container-version.sh /usr/bin/container-version
+RUN chmod +x /usr/bin/container-version
+
+# ╭――――――――――――――――――――╮
+# │ HEALTH             │
+# ╰――――――――――――――――――――╯
+COPY health/tempo-check.sh /etc/container/health.d/tempo-running
+RUN chmod +x /etc/container/health.d/tempo-running
+
+# ╭――――――――――――――――――――╮
+# │ ENTRYPOINT         │
+# ╰――――――――――――――――――――╯
+COPY services/tempo/run /etc/services.d/tempo/run
+RUN chmod +x /etc/services.d/tempo/run
+
+# Standard Tempo ports: 3200 (HTTP), 4317 (OTLP gRPC), 4318 (OTLP HTTP)
+EXPOSE 3200 4317 4318
+WORKDIR /var/tempo

--- a/health/tempo-check.sh
+++ b/health/tempo-check.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ TEMPO - HEALTH CHECK SCRIPT                                              │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# Verifies that Tempo is responding on its configured port.
+
+PORT="${TEMPO_PORT:-3200}"
+HEALTH_ENDPOINT="http://localhost:${PORT}/ready"
+
+if ! curl -fsSL "${HEALTH_ENDPOINT}" > /dev/null 2>&1; then
+    printf "Tempo is not responding on port %s\n" "${PORT}" >&2
+    exit 1
+fi
+
+printf "Tempo is healthy\n"

--- a/scripts/container-version.sh
+++ b/scripts/container-version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ VERSION - TEMPO VERSION REPORT                                          │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# This script returns the Tempo version packaged in the container.
+
+VERSION=$(/usr/bin/tempo --version | awk '{print $3}' | tr -d '[:space:]')
+
+if [ -z "$VERSION" ]; then
+    printf "unknown\n"
+    exit 1
+fi
+
+printf "%s\n" "$VERSION"

--- a/services/tempo/run
+++ b/services/tempo/run
@@ -1,0 +1,17 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ TEMPO - S6 SERVICE SCRIPT                                                │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# This script is an s6 service run script that launches and manages the
+# Tempo server within the container.
+
+APP_USER="tempo"
+CONFIG_FILE="/etc/tempo/tempo.yaml"
+DATA_PATH="/var/tempo"
+
+# Ensure runtime directories exist and have correct ownership.
+mkdir -p "${DATA_PATH}"
+chown -R "${APP_USER}:${APP_USER}" "${DATA_PATH}"
+
+exec s6-setuidgid "${APP_USER}" \
+  /usr/bin/tempo -config.file="${CONFIG_FILE}"


### PR DESCRIPTION
This PR implements a two-stage build for Grafana Tempo from source, using the `gautada/grafana` Containerfile as a template.

Summary of changes:
- Created a two-stage `Containerfile` (Build: golang:1.24-trixie, Final: gautada/debian).
- Added `health/tempo-check.sh` for container health monitoring.
- Added `scripts/container-version.sh` for version reporting.
- Added `services/tempo/run` for s6 service management.

AC Status:
- [x] [Develop] Two-stage build from source implemented.
- [ ] [Integrate] CI build/deploy verification pending.

Risk: Low
CI: Pending